### PR TITLE
fix: use mount from path parameter given during authn

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -225,7 +225,7 @@ func TestBackEnd_ValidateInstancePrincipalLoginNonExistentRole(t *testing.T) {
 func makeRequestAndValidateResponse(t *testing.T, cmdMap map[string]string, expectFailure bool, expectedTTL time.Duration, expectedPolicies []string) {
 
 	role := cmdMap["role"]
-	path := fmt.Sprintf(PathBaseFormat, role)
+	path := fmt.Sprintf(PathBaseFormat, "oci", role)
 	signingPath := PathVersionBase + path
 
 	backend, config, err := initTest(t)

--- a/cli.go
+++ b/cli.go
@@ -54,6 +54,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if !ok {
 		mount = "oci"
 	}
+	mount = strings.TrimSuffix(mount, "/")
 
 	role, ok := m["role"]
 	if !ok {

--- a/cli.go
+++ b/cli.go
@@ -50,13 +50,18 @@ Configuration:
 }
 
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+	mount, ok := m["mount"]
+	if !ok {
+		mount = "oci"
+	}
+
 	role, ok := m["role"]
 	if !ok {
 		return nil, fmt.Errorf("Enter the role")
 	}
 	role = strings.ToLower(role)
 
-	path := fmt.Sprintf(PathBaseFormat, role)
+	path := fmt.Sprintf(PathBaseFormat, mount, role)
 	signingPath := PathVersionBase + path
 
 	loginData, err := CreateLoginData(c.Address(), m, signingPath)

--- a/path_login.go
+++ b/path_login.go
@@ -235,7 +235,7 @@ func requestTargetToMethodURL(requestTarget []string, roleName string) (method s
 
 	// Validate the URL path by inspecting its segments.
 	// The path mount segment of the URL is not validated.
-	segments := strings.Split(parts[1], "/")
+	segments := strings.Split(strings.TrimPrefix(parts[1], "/"), "/")
 	if len(segments) < 5 || segments[0] != PathSegmentVersion || segments[1] != PathSegmentAuth ||
 		segments[len(segments)-2] != PathSegmentLogin || segments[len(segments)-1] != roleName {
 		return "", "", errHeader

--- a/path_login.go
+++ b/path_login.go
@@ -17,7 +17,7 @@ import (
 // These constants store the required http path & method information for validating the signed request
 const (
 	PathVersionBase = "/v1"
-	PathBaseFormat  = "/auth/oci/login/%s"
+	PathBaseFormat  = "/auth/%s/login/%s"
 	PathLoginMethod = "get"
 )
 
@@ -78,7 +78,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 	authenticateRequestHeaders := requestHeaders.(http.Header)
 
 	// Find the targetUrl and Method
-	finalLoginPath := PathVersionBase + fmt.Sprintf(PathBaseFormat, roleName)
+	finalLoginPath := PathVersionBase + fmt.Sprintf(PathBaseFormat, "oci", roleName)
 	method, targetUrl, err := requestTargetToMethodURL(authenticateRequestHeaders[HdrRequestTarget], PathLoginMethod, finalLoginPath)
 	if err != nil {
 		return unauthorizedLogicalResponse(req, b.Logger(), err)


### PR DESCRIPTION
# Overview

Allows the vault-plugin-auth-oci CLI handler to successfully make requests when the plugin backend is mounted at a non-default path.

# Related Issues/Pull Requests

Fixes: #3 

# Contributor Checklist
-  [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
