### PR TITLE
Backport 1.4.3: Use mount from path parameter given during authentication

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -225,7 +225,7 @@ func TestBackEnd_ValidateInstancePrincipalLoginNonExistentRole(t *testing.T) {
 func makeRequestAndValidateResponse(t *testing.T, cmdMap map[string]string, expectFailure bool, expectedTTL time.Duration, expectedPolicies []string) {
 
 	role := cmdMap["role"]
-	path := fmt.Sprintf(PathBaseFormat, role)
+	path := fmt.Sprintf(PathBaseFormat, "oci", role)
 	signingPath := PathVersionBase + path
 
 	backend, config, err := initTest(t)

--- a/cli.go
+++ b/cli.go
@@ -50,13 +50,19 @@ Configuration:
 }
 
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+	mount, ok := m["mount"]
+	if !ok {
+		mount = "oci"
+	}
+	mount = strings.TrimSuffix(mount, "/")
+
 	role, ok := m["role"]
 	if !ok {
 		return nil, fmt.Errorf("Enter the role")
 	}
 	role = strings.ToLower(role)
 
-	path := fmt.Sprintf(PathBaseFormat, role)
+	path := fmt.Sprintf(PathBaseFormat, mount, role)
 	signingPath := PathVersionBase + path
 
 	loginData, err := CreateLoginData(c.Address(), m, signingPath)


### PR DESCRIPTION
This PR backports a bug fix from https://github.com/hashicorp/vault-plugin-auth-oci/pull/7.