### PR TITLE
Update alias name to match the role name, and not just 'name'

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -179,7 +179,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 		},
 		DisplayName: roleName,
 		Alias: &logical.Alias{
-			Name: "name",
+			Name: roleName,
 		},
 	}
 


### PR DESCRIPTION
Fixes a likely bug by using the role's name and not just the constant `name`.