### PR TITLE
Clean up responses to match other plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## Unreleased
 
+## 0.13.1
+
+CHANGES:
+* Repond with a 400 instead of 401 to login errors. [GH-27](https://github.com/hashicorp/vault-plugin-auth-oci/pull/27)
+
 IMPROVEMENTS:
 
+* Return success message when writing role [GH-27](https://github.com/hashicorp/vault-plugin-auth-oci/pull/27)
+* Return error messages when failing to login [GH-27](https://github.com/hashicorp/vault-plugin-auth-oci/pull/27)
 * enable plugin multiplexing [GH-25](https://github.com/hashicorp/vault-plugin-auth-oci/pull/25)
 * update dependencies
   * `github.com/hashicorp/vault/api` v1.9.0

--- a/path_role.go
+++ b/path_role.go
@@ -180,13 +180,13 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
-	var resp logical.Response
+	var resp *logical.Response
 
 	if err := b.setOCIRole(ctx, req.Storage, roleName, roleEntry); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return resp, nil
 }
 
 // Struct to hold the information associated with an OCI role


### PR DESCRIPTION
We accidentally returned an empty response instead of a nil response on successfully writing a role, which suppressed the "Success!" message. This confused users.

Also, when returning a 401 for a login error, the errors are dropped. It is not possible to return a 401 and display the errors cleanly in Vault. So, we changed the response on login errors to 400 (a standard `logical.ErrorResponse`), which matches other plugins' behavior.

This is **not** 100% backwards compatible, but I think that the consistent behavior with other plugins and the error messages being reported is worth it.
