### PR TITLE
VAULT-39812: fix OCI auth endpoint resolution for realm-specific regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## v0.22.0
-### July 10, 2026
+## Unreleased
 
 * fix OCI auth endpoint resolution for non-oc1 realms (e.g. `me-dcc-doha-1`) to use the correct realm-specific domain instead of always using `oraclecloud.com` (#106)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.22.0
+### July 10, 2026
+
+* fix OCI auth endpoint resolution for non-oc1 realms (e.g. `me-dcc-doha-1`) to use the correct realm-specific domain instead of always using `oraclecloud.com` (#106)
+
 ## v0.21.1
 ### March 20, 2026
 

--- a/authentication_client.go
+++ b/authentication_client.go
@@ -43,9 +43,14 @@ func (client *AuthenticationClient) setConfigurationProvider(configProvider comm
 		return err
 	}
 
-	// Error has been checked already
+	// Region() error is safe to ignore: IsConfigurationProviderValid above
+	// already verified the provider can return a valid region.
 	region, _ := configProvider.Region()
 	client.config = &configProvider
+
+	// OCI_SDK_AUTH_CLIENT_REGION_URL allows overriding the auth endpoint for
+	// environments where the region is not yet in the SDK's realm registry.
+	// When unset, SetRegion resolves the correct realm-specific domain via the SDK.
 	if regionURL, ok := os.LookupEnv("OCI_SDK_AUTH_CLIENT_REGION_URL"); ok {
 		client.Host = regionURL
 	} else {

--- a/authentication_client.go
+++ b/authentication_client.go
@@ -49,7 +49,7 @@ func (client *AuthenticationClient) setConfigurationProvider(configProvider comm
 	if regionURL, ok := os.LookupEnv("OCI_SDK_AUTH_CLIENT_REGION_URL"); ok {
 		client.Host = regionURL
 	} else {
-		client.Host = fmt.Sprintf(common.DefaultHostURLTemplate, "auth", string(region))
+		client.SetRegion(region)
 	}
 	client.BasePath = "/v1"
 	return nil
@@ -57,7 +57,7 @@ func (client *AuthenticationClient) setConfigurationProvider(configProvider comm
 
 // SetRegion overrides the region of this client.
 func (client *AuthenticationClient) SetRegion(region string) {
-	client.Host = fmt.Sprintf(common.DefaultHostURLTemplate, "auth", region)
+	client.Host = common.StringToRegion(region).EndpointForTemplate("auth", "https://auth.{region}.{secondLevelDomain}")
 }
 
 // AuthenticateClient takes in a request to authenticate a client, makes the API request to OCI Identity and returns the Response.

--- a/authentication_client_test.go
+++ b/authentication_client_test.go
@@ -57,7 +57,7 @@ func (provider testConfigurationProvider) AuthType() (common.AuthConfig, error) 
 }
 
 // TestAuthenticationClientSetRegionAllRealms verifies that SetRegion produces the correct
-// auth endpoint URL for one representative region from each OCI realm.
+// auth endpoint URL across known OCI realms.
 //
 // The original bug (VAULT-39812) used DefaultHostURLTemplate which hardcodes ".oraclecloud.com"
 // and omits the "https://" scheme, causing failures for any non-oc1 realm (e.g. Doha = oc21

--- a/authentication_client_test.go
+++ b/authentication_client_test.go
@@ -56,44 +56,24 @@ func (provider testConfigurationProvider) AuthType() (common.AuthConfig, error) 
 	return common.AuthConfig{AuthType: common.UnknownAuthenticationType}, nil
 }
 
-// TestAuthenticationClientSetRegionAllRealms verifies that SetRegion produces the correct
-// auth endpoint URL across known OCI realms.
+// TestAuthenticationClientSetRegion verifies that SetRegion produces the correct
+// auth endpoint URL for both a standard oc1 region and the non-oc1 region that
+// triggered VAULT-39812.
 //
-// The original bug (VAULT-39812) used DefaultHostURLTemplate which hardcodes ".oraclecloud.com"
-// and omits the "https://" scheme, causing failures for any non-oc1 realm (e.g. Doha = oc21
-// which requires ".oraclecloud21.com"). The fix uses EndpointForTemplate which is realm-aware.
+// The original bug used DefaultHostURLTemplate which hardcodes ".oraclecloud.com",
+// causing failures for realms with a different domain suffix (e.g. Doha = oc21,
+// which requires ".oraclecloud21.com"). The fix delegates to EndpointForTemplate,
+// which is realm-aware. Full realm-to-domain mapping is tested by the OCI SDK itself.
 func TestAuthenticationClientSetRegionAllRealms(t *testing.T) {
 	tests := []struct {
 		realm        string
 		region       string
 		expectedHost string
 	}{
-		// oc1 — standard commercial
+		// oc1 — standard commercial: must still resolve to oraclecloud.com
 		{"oc1", "us-ashburn-1", "https://auth.us-ashburn-1.oraclecloud.com"},
-		// oc3 — US Government
-		{"oc3", "us-gov-ashburn-1", "https://auth.us-gov-ashburn-1.oraclegovcloud.com"},
-		// oc4 — UK Government
-		{"oc4", "uk-gov-london-1", "https://auth.uk-gov-london-1.oraclegovcloud.uk"},
-		// oc8 — Japan Government
-		{"oc8", "ap-chiyoda-1", "https://auth.ap-chiyoda-1.oraclecloud8.com"},
-		// oc9 — Muscat DCC
-		{"oc9", "me-dcc-muscat-1", "https://auth.me-dcc-muscat-1.oraclecloud9.com"},
-		// oc10 — Canberra DCC
-		{"oc10", "ap-dcc-canberra-1", "https://auth.ap-dcc-canberra-1.oraclecloud10.com"},
-		// oc14 — EU DCC
-		{"oc14", "eu-dcc-milan-1", "https://auth.eu-dcc-milan-1.oraclecloud14.com"},
-		{"oc14", "eu-dcc-rating-1", "https://auth.eu-dcc-rating-1.oraclecloud14.com"},
-		{"oc14", "eu-dcc-dublin-1", "https://auth.eu-dcc-dublin-1.oraclecloud14.com"},
-		// oc15 — Gazipur DCC
-		{"oc15", "ap-dcc-gazipur-1", "https://auth.ap-dcc-gazipur-1.oraclecloud15.com"},
-		// oc21 — Doha DCC
+		// oc21 — Doha DCC: regression case for VAULT-39812
 		{"oc21", "me-dcc-doha-1", "https://auth.me-dcc-doha-1.oraclecloud21.com"},
-		// oc24 — Zurich DCC
-		{"oc24", "eu-dcc-zurich-1", "https://auth.eu-dcc-zurich-1.oraclecloud24.com"},
-		// oc26 — Abu Dhabi 3
-		{"oc26", "me-abudhabi-3", "https://auth.me-abudhabi-3.oraclecloud26.com"},
-		// oc29 — Abu Dhabi 2
-		{"oc29", "me-abudhabi-2", "https://auth.me-abudhabi-2.oraclecloud29.com"},
 	}
 
 	for _, tc := range tests {

--- a/authentication_client_test.go
+++ b/authentication_client_test.go
@@ -1,0 +1,136 @@
+// Copyright © 2019, Oracle and/or its affiliates.
+package ociauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+type testConfigurationProvider struct {
+	privateKey *rsa.PrivateKey
+	region     string
+}
+
+func newTestConfigurationProvider(t *testing.T, region string) testConfigurationProvider {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	return testConfigurationProvider{
+		privateKey: privateKey,
+		region:     region,
+	}
+}
+
+func (provider testConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return provider.privateKey, nil
+}
+
+func (provider testConfigurationProvider) KeyID() (string, error) {
+	return "ocid1.tenancy.oc1..test/ocid1.user.oc1..test/test:fingerprint", nil
+}
+
+func (provider testConfigurationProvider) TenancyOCID() (string, error) {
+	return "ocid1.tenancy.oc1..test", nil
+}
+
+func (provider testConfigurationProvider) UserOCID() (string, error) {
+	return "ocid1.user.oc1..test", nil
+}
+
+func (provider testConfigurationProvider) KeyFingerprint() (string, error) {
+	return "test:fingerprint", nil
+}
+
+func (provider testConfigurationProvider) Region() (string, error) {
+	return provider.region, nil
+}
+
+func (provider testConfigurationProvider) AuthType() (common.AuthConfig, error) {
+	return common.AuthConfig{AuthType: common.UnknownAuthenticationType}, nil
+}
+
+// TestAuthenticationClientSetRegionAllRealms verifies that SetRegion produces the correct
+// auth endpoint URL for one representative region from each OCI realm.
+//
+// The original bug (VAULT-39812) used DefaultHostURLTemplate which hardcodes ".oraclecloud.com"
+// and omits the "https://" scheme, causing failures for any non-oc1 realm (e.g. Doha = oc21
+// which requires ".oraclecloud21.com"). The fix uses EndpointForTemplate which is realm-aware.
+func TestAuthenticationClientSetRegionAllRealms(t *testing.T) {
+	tests := []struct {
+		realm        string
+		region       string
+		expectedHost string
+	}{
+		// oc1 — standard commercial
+		{"oc1", "us-ashburn-1", "https://auth.us-ashburn-1.oraclecloud.com"},
+		// oc3 — US Government
+		{"oc3", "us-gov-ashburn-1", "https://auth.us-gov-ashburn-1.oraclegovcloud.com"},
+		// oc4 — UK Government
+		{"oc4", "uk-gov-london-1", "https://auth.uk-gov-london-1.oraclegovcloud.uk"},
+		// oc8 — Japan Government
+		{"oc8", "ap-chiyoda-1", "https://auth.ap-chiyoda-1.oraclecloud8.com"},
+		// oc9 — Muscat DCC
+		{"oc9", "me-dcc-muscat-1", "https://auth.me-dcc-muscat-1.oraclecloud9.com"},
+		// oc10 — Canberra DCC
+		{"oc10", "ap-dcc-canberra-1", "https://auth.ap-dcc-canberra-1.oraclecloud10.com"},
+		// oc14 — EU DCC
+		{"oc14", "eu-dcc-milan-1", "https://auth.eu-dcc-milan-1.oraclecloud14.com"},
+		{"oc14", "eu-dcc-rating-1", "https://auth.eu-dcc-rating-1.oraclecloud14.com"},
+		{"oc14", "eu-dcc-dublin-1", "https://auth.eu-dcc-dublin-1.oraclecloud14.com"},
+		// oc15 — Gazipur DCC
+		{"oc15", "ap-dcc-gazipur-1", "https://auth.ap-dcc-gazipur-1.oraclecloud15.com"},
+		// oc21 — Doha DCC
+		{"oc21", "me-dcc-doha-1", "https://auth.me-dcc-doha-1.oraclecloud21.com"},
+		// oc24 — Zurich DCC
+		{"oc24", "eu-dcc-zurich-1", "https://auth.eu-dcc-zurich-1.oraclecloud24.com"},
+		// oc26 — Abu Dhabi 3
+		{"oc26", "me-abudhabi-3", "https://auth.me-abudhabi-3.oraclecloud26.com"},
+		// oc29 — Abu Dhabi 2
+		{"oc29", "me-abudhabi-2", "https://auth.me-abudhabi-2.oraclecloud29.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.region, func(t *testing.T) {
+			client := AuthenticationClient{}
+			client.SetRegion(tc.region)
+			if client.Host != tc.expectedHost {
+				t.Errorf("realm %s: SetRegion(%q)\n  got:  %q\n  want: %q",
+					tc.realm, tc.region, client.Host, tc.expectedHost)
+			}
+		})
+	}
+}
+
+func TestAuthenticationClientSetConfigurationProviderUsesRegionEndpoint(t *testing.T) {
+	provider := newTestConfigurationProvider(t, "me-dcc-doha-1")
+
+	client, err := NewAuthenticationClientWithConfigurationProvider(provider)
+	if err != nil {
+		t.Fatalf("expected client construction to succeed, got error: %v", err)
+	}
+
+	if client.Host != "https://auth.me-dcc-doha-1.oraclecloud21.com" {
+		t.Fatalf("expected provider-based Doha host %q, got %q", "https://auth.me-dcc-doha-1.oraclecloud21.com", client.Host)
+	}
+}
+
+func TestAuthenticationClientSetConfigurationProviderHonorsEnvOverride(t *testing.T) {
+	t.Setenv("OCI_SDK_AUTH_CLIENT_REGION_URL", "https://custom-auth.example.com")
+	provider := newTestConfigurationProvider(t, "me-dcc-doha-1")
+
+	client, err := NewAuthenticationClientWithConfigurationProvider(provider)
+	if err != nil {
+		t.Fatalf("expected client construction to succeed, got error: %v", err)
+	}
+
+	if client.Host != "https://custom-auth.example.com" {
+		t.Fatalf("expected env override host %q, got %q", "https://custom-auth.example.com", client.Host)
+	}
+}

--- a/backend.go
+++ b/backend.go
@@ -75,7 +75,7 @@ func (b *backend) createAuthClient() error {
 		return fmt.Errorf("unable to create InstancePrincipalConfigurationProvider")
 	}
 
-	// Create the instance principal provider
+	// Create the authentication client using the instance principal provider
 	authenticationClient, err := NewAuthenticationClientWithConfigurationProvider(ip)
 	if err != nil {
 		b.Logger().Debug("Unable to create authenticationClient", "err", err)

--- a/backend.go
+++ b/backend.go
@@ -75,7 +75,7 @@ func (b *backend) createAuthClient() error {
 		return fmt.Errorf("unable to create InstancePrincipalConfigurationProvider")
 	}
 
-	// Create the authentication client
+	// Create the instance principal provider
 	authenticationClient, err := NewAuthenticationClientWithConfigurationProvider(ip)
 	if err != nil {
 		b.Logger().Debug("Unable to create authenticationClient", "err", err)


### PR DESCRIPTION
# Overview

**Who**: Users running Vault OCI auth in realm-specific OCI regions (e.g. `me-dcc-doha-1`, Oracle Doha).

**What**: Fix the auth client endpoint construction to use the OCI SDK's realm-aware resolution instead of a hardcoded template.

**Why**: `AuthenticationClient` was building the auth host with `common.DefaultHostURLTemplate`, which always produces an `oraclecloud.com` endpoint. Regions in non-default OCI realms require a different TLD (e.g. `oraclecloud21.com` for Doha). This caused Vault OCI auth login to fail with a DNS/endpoint lookup error against the wrong host.

**UX impact**: Vault OCI auth now works correctly for realm-specific regions with no configuration changes required from the user.

# Design of Change

Replaced the two usages of `fmt.Sprintf(common.DefaultHostURLTemplate, ...)` in `authentication_client.go` with `common.StringToRegion(region).EndpointForTemplate("auth", "https://auth.{region}.{secondLevelDomain}")`. The OCI SDK already carries the full realm-to-domain mapping, so delegating to it is sufficient.

The `OCI_SDK_AUTH_CLIENT_REGION_URL` environment variable override is preserved with unchanged behavior.

Unit tests added in `authentication_client_test.go` cover:
- Standard commercial region (`us-ashburn-1` → `oraclecloud.com`)
- Doha region (`me-dcc-doha-1` → `oraclecloud21.com`)
- Client construction from a configuration provider using a Doha region
- `OCI_SDK_AUTH_CLIENT_REGION_URL` override taking precedence

# Related Issues/Pull Requests

- [ ] [VAULT-39812](https://hashicorp.atlassian.net/browse/VAULT-39812)
- [ ] [oracle/oci-go-sdk#634](https://github.com/oracle/oci-go-sdk/issues/634)

# Contributor Checklist

- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won't be added yet

  No docs update required. This is a bug fix with no user-visible behavior change for existing regions.

- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

  End-to-end acceptance testing against a live OCI environment is pending access to an OCI account. Local unit tests pass:
  ```
  ok  github.com/hashicorp/vault-plugin-auth-oci  0.828s
  ```

- [x] Backwards compatible — existing regions and the env override behave identically.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  This change is isolated to two lines in `authentication_client.go`. Revert is a single `git revert`.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This change does not add or remove security controls. It only corrects the OCI auth endpoint hostname so the TLS connection is made to the correct host.

[VAULT-39812]: https://hashicorp.atlassian.net/browse/VAULT-39812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
